### PR TITLE
Fix rights error in CreateFileW driver part

### DIFF
--- a/miscellaneous-reversing-forensics/windows-kernel-internals/sending-commands-from-userland-to-your-kernel-driver-using-ioctl.md
+++ b/miscellaneous-reversing-forensics/windows-kernel-internals/sending-commands-from-userland-to-your-kernel-driver-using-ioctl.md
@@ -236,7 +236,7 @@ int main(char argc, char ** argv)
 
     RtlCopyMemory(inBuffer, argv[1], strlen(argv[1]));
     
-    device = CreateFileW(L"\\\\.\\SpotlessDeviceLink", GENERIC_ALL, 0, 0, OPEN_EXISTING, FILE_ATTRIBUTE_SYSTEM, 0);
+    device = CreateFileW(L"\\\\.\\SpotlessDeviceLink", GENERIC_WRITE | GENERIC_READ | GENERIC_EXECUTE, 0, 0, OPEN_EXISTING, FILE_ATTRIBUTE_SYSTEM, 0);
     
     if (device == INVALID_HANDLE_VALUE)
     {


### PR DESCRIPTION
I was checking your solution and it's pretty straight forward but when I tried to reproduce it I got the following error:
`> Could not open device: 0x5` : **Access is denied.**

Didn't go too deep and research but looks like something has changed since the workshop was created and currently `GENERIC_ALL` is abstractly less than `GENERIC_WRITE | GENERIC_READ | GENERIC_EXECUTE`

When I checked for the error I got all the things right except the eventual result:
```cpp
int _GENERIC_ALL = GENERIC_ALL; // doesn't work
int GENERIC_WRITE_GENERIC_READ_GENERIC_EXECUTE = GENERIC_WRITE | GENERIC_READ | GENERIC_EXECUTE; // works

cout << "GENERIC_ALL: " << hex << _GENERIC_ALL << endl << "GENERIC_WRITE | GENERIC_READ | GENERIC_EXECUTE: " \ 
<< GENERIC_WRITE_GENERIC_READ_GENERIC_EXECUTE << endl;

GENERIC_ALL: 10000000
GENERIC_WRITE | GENERIC_READ | GENERIC_EXECUTE: e0000000

0x10000000 : 00010000000000000000000000000000
0xe0000000 : 11100000000000000000000000000000
```

So looks like everything works as in the [manual](https://github.com/MicrosoftDocs/win32/blob/docs/desktop-src/SecAuthZ/access-mask-format.md) but some internal processes have changed

OS Windows 10 Pro x64 19041