### PR TITLE
fix typo in apc-queue-code-injection

### DIFF
--- a/offensive-security/code-injection-process-injection/apc-queue-code-injection.md
+++ b/offensive-security/code-injection-process-injection/apc-queue-code-injection.md
@@ -81,7 +81,7 @@ DWORD SleepEx(
 );
 ```
 
-Let's put the new project to sleep in both alertable and non-alertable states and see what heppens when an APC is queued to it.
+Let's put the new project to sleep in both alertable and non-alertable states and see what happens when an APC is queued to it.
 
 ### Alertable State
 


### PR DESCRIPTION
Hi.
In offensive-security/code-injection-process-injection/apc-queue-code-injection.md, there was a typo.
Instead of `happens`, there seems to be `heppens`.
Thanks